### PR TITLE
New Feature: Edit tab group name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vs-tab-groups",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vs-tab-groups",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "dependencies": {
         "vscode-uri": "^3.0.8"
       },

--- a/package.json
+++ b/package.json
@@ -148,14 +148,19 @@
           "group": "vs_tab_groups_3@1"
         },
         {
-          "command": "vs_tab_groups.editTabGroupIcon",
+          "command": "vs_tab_groups.editTabGroupName",
           "when": "view == vs_tab_groups && viewItem == vstg_root_item",
           "group": "vs_tab_groups_4@0"
         },
         {
-          "command": "vs_tab_groups.removeTabGroup",
+          "command": "vs_tab_groups.editTabGroupIcon",
           "when": "view == vs_tab_groups && viewItem == vstg_root_item",
           "group": "vs_tab_groups_4@1"
+        },
+        {
+          "command": "vs_tab_groups.removeTabGroup",
+          "when": "view == vs_tab_groups && viewItem == vstg_root_item",
+          "group": "vs_tab_groups_4@2"
         },
         {
           "command": "vs_tab_groups.moveUp",
@@ -268,6 +273,10 @@
       {
         "command": "vs_tab_groups.editTabGroupIcon",
         "title": "Edit Tab Group Icon"
+      },
+      {
+        "command": "vs_tab_groups.editTabGroupName",
+        "title": "Edit Tab Group Name"
       },
       {
         "command": "vs_tab_groups.removeTabGroup",

--- a/src/TreeDataProvider.ts
+++ b/src/TreeDataProvider.ts
@@ -39,6 +39,7 @@ export class TreeDataProvider implements vscode.TreeDataProvider<TreeItem> {
         vscode.commands.registerCommand("vs_tab_groups.closeTabGroup", (item) => this.closeTabGroup(item));
         vscode.commands.registerCommand("vs_tab_groups.editTabGroupIcon", (item) => this.editTabGroupIcon(item));
         vscode.commands.registerCommand("vs_tab_groups.removeTabGroup", (item) => this.removeTabGroup(item));
+        vscode.commands.registerCommand("vs_tab_groups.editTabGroupName", (item) => this.editTabGroupName(item));
 
         // Low level, actions on tabs
         vscode.commands.registerCommand("vs_tab_groups.openTab", (item) => this.openTab(item));
@@ -530,6 +531,27 @@ export class TreeDataProvider implements vscode.TreeDataProvider<TreeItem> {
 
             this.m_onDidChangeTreeData.fire(undefined);
         }
+    }
+
+    /**
+     * Change the name of the group's root.
+     * @param item The item representing the root of the group.
+     */
+    async editTabGroupName(item: TreeItem) {
+        const input = await vscode.window.showInputBox({
+            prompt: "Type in the new name of the tab group.\n",
+        });
+
+        if (input && input !== "") {
+            if (this.labelExists(input)) {
+                vscode.window.showErrorMessage(`Can not have two tab groups with name '${input}'`);
+                return;
+            }
+
+            item.label = input
+            this.m_onDidChangeTreeData.fire(undefined);
+        }
+        this.save();
     }
 
     /**


### PR DESCRIPTION
Hey Daniel, I have been using your vscode extension and it helps me a lot.
Recently, I needed to rename some TabGroups and I saw that is not possible.
So, I did this PR with small modifications that add a new function to edit the Tab Group Name.
Is it possible to merge it in your code to be available to use in my day by day?
Feel free to check the code and give suggestions or modifications if needed.

PS.: Exists a way to add TabGroup inside another TabGroup? I tried it, but was unsuccessful. So, if this feature does not exist yet I think I will develop it too, but I have to search and learn a little more about this VSCode API. 